### PR TITLE
Do not infloop if not visible

### DIFF
--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -85,9 +85,10 @@ public class Risk {
 
         visuals.log(activePlayers.get(0) + " has won!");
 
-        while(true) {
-            visuals.update();
-        }
+        if (visible)
+            while(true) {
+                visuals.update();
+            }
     }
 
     public int getTurn() {


### PR DESCRIPTION
The infloop has to be there to update the visuals, but if the
visuals aren't enabled then you don't want to update them, of
course.