### PR TITLE
Combat and mars planning fixes

### DIFF
--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -20,7 +20,8 @@ public class Risk implements CombatInterface{
 
     // Variables to be customized by debugger
     private boolean visible = true;
-    private int playerAmount = 5;
+    private int randomPlayers = 5;
+    private int marsPlayers = 1;
 
     public static Random random;
 
@@ -79,7 +80,7 @@ public class Risk implements CombatInterface{
         board = new Board();
         defeatedPlayers = new ArrayList<Player>();
         nrOfStartingUnits = 30;
-        initializePlayers();
+        initializePlayers(randomPlayers,marsPlayers);
         Integer currentPlayerIndex = divideTerritories();
         initialPlaceReinforcements(currentPlayerIndex);
         currentPlayer = activePlayers.get(0);
@@ -223,12 +224,12 @@ public class Risk implements CombatInterface{
             Color.MAGENTA
     };
 
-    private void initializePlayers() {
+    private void initializePlayers(int randoms, int marses) {
         activePlayers = new ArrayList<>();
         // TODO deciding number of startingUnits using number of players and evt. number
         // territorries
         int i;
-        for (i = 0; i < playerAmount - 1; i++) {
+        for (i = 0; i < randoms; i++) {
             Objective objective = new Objective(Objective.type.TOTAL_DOMINATION);
             Color color;
             if (i < playerColors.length) {
@@ -237,20 +238,22 @@ public class Risk implements CombatInterface{
                 color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
                         Risk.random.nextFloat() * 0.8f + 0.2f);
             }
-            RandomBot player = new RandomBot(objective, 0, "player" + i,color);
+            RandomBot player = new RandomBot(objective, 0, "Player " + i + " (Random Bot)",color);
             activePlayers.add(player);
         }
-        // Add mars agent
-        Color color;
-        if (i < playerColors.length) {
-            color = playerColors[i];
-        } else {
-            color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
-                    Risk.random.nextFloat() * 0.8f + 0.2f);
+
+        for (; i < randoms + marses; i++) {
+	        Color color;
+	        if (i < playerColors.length) {
+	            color = playerColors[i];
+	        } else {
+	            color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
+	                    Risk.random.nextFloat() * 0.8f + 0.2f);
+	        }
+	        Objective objective = new Objective(Objective.type.TOTAL_DOMINATION);
+	        Mars player = new Mars(this, objective, 0, "Player " + i + " (MARS)",color);
+	        activePlayers.add(player);
         }
-        Objective objective = new Objective(Objective.type.TOTAL_DOMINATION);
-        Mars player = new Mars(this, objective, 0, "Mars agent",color);
-        activePlayers.add(player);
     }
 
     // Divide players randomly over territories

--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -178,8 +178,9 @@ public class Risk implements CombatInterface{
                 currentPlayer.hand.setInfantry(currentPlayer.hand.getInfantry() + defender.hand.getInfantry());
                 while (currentPlayer.hand.getNumberOfCards() > 4)
                     currentPlayer.turnInCards(board);
-                currentPlayer.placeReinforcements(board);
                 activePlayers.remove(defender);
+                if (activePlayers.size() > 1)
+                	currentPlayer.placeReinforcements(board);
                 defeatedPlayers.add(defender);
             }
         }

--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -20,8 +20,8 @@ public class Risk implements CombatInterface{
 
     // Variables to be customized by debugger
     private boolean visible = true;
-    private int randomPlayers = 5;
-    private int marsPlayers = 1;
+    private int randomPlayers = 4;
+    private int marsPlayers = 2;
 
     public static Random random;
 

--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
 
-import infomgmag.mars.Mars;
-
 /**
  * This class contains the main() method. This class is the bridge between the
  * visual presentation of the game (RiskVisual) and the data presentation of the

--- a/src/infomgmag/RiskVisual.java
+++ b/src/infomgmag/RiskVisual.java
@@ -160,7 +160,7 @@ public class RiskVisual extends JFrame {
             g.drawImage(map, 0, 0, gameWidth, gameHeight, null);
     }
 
-    long targetFrameDuration = 25;
+    long targetFrameDuration = 10;
     long frameDuration = 1000;
     long lastFrameTime;
 

--- a/src/infomgmag/RiskVisual.java
+++ b/src/infomgmag/RiskVisual.java
@@ -160,7 +160,7 @@ public class RiskVisual extends JFrame {
             g.drawImage(map, 0, 0, gameWidth, gameHeight, null);
     }
 
-    long targetFrameDuration = 10;
+    long targetFrameDuration = 25;
     long frameDuration = 1000;
     long lastFrameTime;
 

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -170,7 +170,11 @@ public class CountryAgent {
     			bestBid = offBid;
     		}
     	}
-    	this.finalGoal = ((OffensiveBid)bestBid).getGoal();
+    	if (bestBid == null) {
+    		this.finalGoal = new ArrayList<>();
+    	} else {
+    		this.finalGoal = ((OffensiveBid)bestBid).getGoal();
+    	}
     	DefensiveBid defBid = getDefensiveBid(null, unitsLeft, agentValues);
         if(bestBid == null || defBid.getUtility() > bestBid.getUtility()) {
             bestBid = defBid;

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -169,12 +169,12 @@ public class CountryAgent {
     		if(bestBid == null || offBid.getUtility() > bestBid.getUtility()) {
     			bestBid = offBid;
     		}
-    		
-    		DefensiveBid defBid = getDefensiveBid(null, unitsLeft, agentValues);
-    		if(bestBid == null || defBid.getUtility() > bestBid.getUtility()) {
-    			bestBid = defBid;
-    		}
     	}
+    	this.finalGoal = ((OffensiveBid)bestBid).getGoal();
+    	DefensiveBid defBid = getDefensiveBid(null, unitsLeft, agentValues);
+        if(bestBid == null || defBid.getUtility() > bestBid.getUtility()) {
+            bestBid = defBid;
+        }
     	return bestBid;
     }
     
@@ -220,23 +220,26 @@ public class CountryAgent {
         return new AttackBid(territory, finalGoal.get(finalGoal.size() - 1).getTerritory());
     }
     
-    public void createGoal() {
-        createGoal(new ArrayList<CountryAgent>());
+    public void createGoals() {
+        for (CountryAgent ca : adjacentAgents) {
+            ArrayList<CountryAgent> goal = new ArrayList<CountryAgent>();
+            goal.add(this);
+            ca.createGoals(goal);
+        }
     }
     
-    public void createGoal(ArrayList<CountryAgent> countries){
-        if(this.getTerritory().getOwner() == mars) {
-            this.receivemessagefriendly(countries);
-        } else if(mars.goalLength > countries.size()) {
-            ArrayList<CountryAgent> copiedCountries = new ArrayList<CountryAgent>();
-            for(CountryAgent ca : countries){
-                copiedCountries.add(ca);
-            }
-            
-            copiedCountries.add(this);
-            for(CountryAgent neighbour : this.getAdjacentAgents()) {
-                if(!countries.contains(neighbour)) {
-                    neighbour.createGoal(copiedCountries);
+    public void createGoals(ArrayList<CountryAgent> goal) {
+        if(goal.size() >= Mars.goalLength)
+            return;
+
+        if(territory.getOwner() == mars) {
+            goalList.add(goal);
+        } else {
+            for(CountryAgent ca : adjacentAgents) {
+                if (!goal.contains(ca)) {
+                    ArrayList<CountryAgent> newGoal = (ArrayList<CountryAgent>) goal.clone();
+                    newGoal.add(this);
+                    createGoals(newGoal);
                 }
             }
         }
@@ -244,7 +247,7 @@ public class CountryAgent {
 
     public void updateFinalGoal() {
         if(finalGoal.isEmpty())
-            createGoal();
+            createGoals();
     }
 }
 

--- a/src/infomgmag/mars/Mars.java
+++ b/src/infomgmag/mars/Mars.java
@@ -28,7 +28,7 @@ public class Mars extends Player {
     private Double earmiesweight = -0.03;
     public static final Integer goalLength = 4;
     
-    public static final Double WIN_PERCENTAGE = 0.5;
+    public static final Double WIN_PERCENTAGE = 0.6;
 
     public Mars(Risk risk, Objective objective, Integer reinforcements, String name, Color color) {
         super(objective, reinforcements, name, color);
@@ -123,20 +123,6 @@ public class Mars extends Player {
         int transferredunits = combatMove.getAttackingTerritory().getNUnits() - 1;
         combatMove.getDefendingTerritory().setUnits(transferredunits);
         combatMove.getAttackingTerritory().setUnits(combatMove.getAttackingTerritory().getNUnits() - transferredunits);
-
-        combatMove.getAttackingTerritory().getCountryAgent().getFinalGoal().remove(combatMove.getAttackingTerritory().getCountryAgent().getFinalGoal().size() - 1);
-
-        ArrayList<CountryAgent> newGoals = new ArrayList<>();
-
-        for (CountryAgent ca : combatMove.getAttackingTerritory().getCountryAgent().getFinalGoal()){
-            newGoals.add(ca);
-        }
-        combatMove.getDefendingTerritory().getCountryAgent().setFinalGoal(newGoals);
-
-        combatMove.getAttackingTerritory().getCountryAgent().getFinalGoal().clear();
-        
-        countryAgentsByTerritory.get(combatMove.getAttackingTerritory()).updateFinalGoal();
-        
     }
 
     @Override

--- a/src/infomgmag/mars/Mars.java
+++ b/src/infomgmag/mars/Mars.java
@@ -157,7 +157,7 @@ public class Mars extends Player {
         for (CountryAgent sender: countryAgents) {
         	if(sender.getTerritory().getOwner() != this) {
 	            ArrayList<CountryAgent> initialList = new ArrayList<CountryAgent>();
-	            sender.createGoal();
+	            sender.createGoals();
         	}
         }
 
@@ -169,8 +169,6 @@ public class Mars extends Player {
                 break;
         }
     }
-    
-    
 
     private ReinforcementBid getBestBid(int units){
     	ReinforcementBid bestBid = null;


### PR DESCRIPTION
- Update goals before any decision if they might have changed, improving mars planning ability and fixing many crashes because of `null` and empty goals (Closes #99)
- Fix bug where program would crash when taking last territory
- Update parameters and player creation so one can easily set the amount of mars as well
- Fix bug where multiple mars agents in the same game would cause a crash on territory takeover
- Removed some unnecessary imports
- Rewrote goal propagation to be more easily understood