### PR TITLE
Better utilities

### DIFF
--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -118,6 +118,7 @@ public class CountryAgent {
         }
         goalValue += (goal.completesContinentFor(mars) ? 1 : 0) * mars.getPersonality().getOwnWholeContinentWeight();
         goalValue += goal.killsPlayers(mars) * mars.getPersonality().getKillEnemyWeight();
+        goalValue += territory.getUnits() * mars.getPersonality().getClusteringWeight();
         return goalValue;
     }
 
@@ -152,13 +153,6 @@ public class CountryAgent {
         return (getGoalUtility(goal,i) - getGoalUtility(goal,0)) / (i > 0 ? i : 1);
     }
 
-
-    private double getDefenseUtility(Integer i) {
-        double v = value;
-        double d = getDefenseOdds(this.getTerritory().getUnits() + i);
-        return v * d;
-    }
-    
     private double getDefenseUtilityPerUnit(int i) {
         return (getDefenseUtility(i) - getDefenseUtility(0)) / (i > 0 ? i : 1);
     }
@@ -259,5 +253,17 @@ public class CountryAgent {
                 }
             }
         }
+    }
+
+    public ReinforcementBid getAttackBid() {
+        ArrayList<ReinforcementBid> result = new ArrayList<>();
+        for (Goal goal : goalList) {
+            double bidUtil = getGoalUtility(goal, 0);
+            OffensiveBid bid = new OffensiveBid(this, goal, 0, bidUtil);
+            result.add(bid);
+        }
+        double bidUtil = getDefenseUtility(0);
+        result.add(new DefensiveBid(this, 0, bidUtil));
+        return result.stream().max((x, y) -> (x.getUtility() < y.getUtility() ? -1 : (x.getUtility() == y.getUtility() ? 0 : 1))).get();
     }
 }

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -172,16 +172,9 @@ public class CountryAgent {
     }
     
     private double getGoalUtilityPerUnit(Goal goal, Integer i) {
-        double total = getGoalUtility(goal, i);
-        if (i == 0) {
-            return total;
-        }
-        return total / i;
+        return (getGoalUtility(goal,i) - getGoalUtility(goal,0)) / i;
     }
 
-    private Double getTerritoryValue(HashMap<CountryAgent, Double> agentValues) {
-        return agentValues.get(this);
-    }
 
     private double getDefenseUtility(Integer i) {
         double v = getValue();
@@ -190,11 +183,7 @@ public class CountryAgent {
     }
     
     private double getDefenseUtilityPerUnit(Integer i) {
-        double total = getDefenseUtility(i);
-        if (i == 0) {
-            return total;
-        }
-        return total / i;
+        return (getDefenseUtility(i) - getDefenseUtility(0)) / i;
     }
 
     public ArrayList<ReinforcementBid> getBids(Integer unitsLeft) {
@@ -202,9 +191,7 @@ public class CountryAgent {
         for (Goal goal : goalList) {
             result.addAll(getOffensiveBids(unitsLeft, goal));
         }
-
-        DefensiveBid defBid = getDefensiveBid(unitsLeft);
-        result.add(defBid);
+        result.addAll(getDefensiveBids(unitsLeft));
         return result;
     }
 
@@ -218,15 +205,13 @@ public class CountryAgent {
                 .get();
 
     }
-    public DefensiveBid getDefensiveBid(Integer unitsLeft) {
-        DefensiveBid bestBid = null;
+    public ArrayList<DefensiveBid> getDefensiveBids(Integer unitsLeft) {
+        ArrayList<DefensiveBid> result = new ArrayList<>();
         for (int i = 0; i <= unitsLeft; i++) {
     		double bidUtil = getDefenseUtilityPerUnit(i);
-            if (bestBid == null || bidUtil > bestBid.getUtility()) {
-                bestBid = new DefensiveBid(this, i, bidUtil);
-            }
+    		result.add(new DefensiveBid(this, i, bidUtil));
         }
-        return bestBid;
+        return result;
     }
     
     public ArrayList<FortifierBid> getFortifierBids () {

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -172,7 +172,7 @@ public class CountryAgent {
     }
     
     private double getGoalUtilityPerUnit(Goal goal, Integer i) {
-        return (getGoalUtility(goal,i) - getGoalUtility(goal,0)) / i;
+        return (getGoalUtility(goal,i) - getGoalUtility(goal,0)) / (i > 0 ? i : 1);
     }
 
 
@@ -183,7 +183,7 @@ public class CountryAgent {
     }
     
     private double getDefenseUtilityPerUnit(Integer i) {
-        return (getDefenseUtility(i) - getDefenseUtility(0)) / i;
+        return (getDefenseUtility(i) - getDefenseUtility(0)) / (i > 0 ? i : 1);
     }
 
     public ArrayList<ReinforcementBid> getBids(Integer unitsLeft) {

--- a/src/infomgmag/mars/Mars.java
+++ b/src/infomgmag/mars/Mars.java
@@ -125,7 +125,6 @@ public class Mars extends Player {
     public void placeReinforcements(Board board) {
         for (CountryAgent ca : countryAgents) {
             ca.clearGoals();
-            ca.calculateOwnershipValue(personality);
         }
 
         for (CountryAgent sender : countryAgents) {
@@ -137,6 +136,7 @@ public class Mars extends Player {
         while (reinforcements > 0) {
             ArrayList<ReinforcementBid> bids = new ArrayList<>();
             for (CountryAgent ca : countryAgents) {
+                ca.calculateOwnershipValue(personality);
                 if (ca.getTerritory().getOwner() == this) {
                     bids.addAll(ca.getBids(reinforcements));
                 }
@@ -183,7 +183,7 @@ public class Mars extends Player {
                     .filter(ca -> ca.getTerritory().getOwner() == this).filter(ca -> ca.bordersEnemy())
                     .filter(ca -> ca.getTerritory().getUnits() > 1)
                     // Collect all offensive bids
-                    .map(ca -> ca.getBestBid(0)).filter(x -> x instanceof OffensiveBid).map(x -> (OffensiveBid) x)
+                    .map(ca -> ca.getAttackBid()).filter(x -> x instanceof OffensiveBid).map(x -> (OffensiveBid) x)
                     // Create attackbids from the best
                     .max((x, y) -> x.getUtility() < y.getUtility() ? -1 : (x.getUtility() == y.getUtility() ? 0 : 1));
             

--- a/src/infomgmag/mars/Personality.java
+++ b/src/infomgmag/mars/Personality.java
@@ -14,6 +14,7 @@ public class Personality {
     private double defensiveMultiplier;
     private double killEnemyWeight;
     private String name;
+    private double clusteringWeight;
 
     public Personality(String name,
                        double defensiveMultiplier,
@@ -27,6 +28,7 @@ public class Personality {
                        double enemyOwnsWholeContinentWeight,
                        double percentageOfContinentWeight,
                        double killEnemyWeight,
+                       double clusteringWeight,
                        int goalLength){
         this.name = name;
         this.defensiveMultiplier = defensiveMultiplier;
@@ -41,6 +43,7 @@ public class Personality {
         this.percentageOfContinentWeight = percentageOfContinentWeight;
         this.killEnemyWeight = killEnemyWeight;
         this.goalLength = goalLength;
+        this.clusteringWeight = clusteringWeight;
     }
 
     public String getName() {
@@ -97,5 +100,9 @@ public class Personality {
 
     public double getKillEnemyWeight() {
         return killEnemyWeight;
+    }
+
+    public double getClusteringWeight() {
+        return clusteringWeight;
     }
 }

--- a/src/infomgmag/mars/PersonalityFactory.java
+++ b/src/infomgmag/mars/PersonalityFactory.java
@@ -15,6 +15,7 @@ public class PersonalityFactory {
                 4.0,
                 5.0,
                 80.0,
+                0.25,
                 4);
     }
 
@@ -32,13 +33,14 @@ public class PersonalityFactory {
                 4.0,
                 5.0,
                 40.0,
+                0.05,
                 4);
     }
 
     public static Personality defensivePersonality() {
         return new Personality(
                 "Defensive",
-                30.5,
+                40.0,
                 40.0,
                 1.2,
                 -0.3,
@@ -47,8 +49,9 @@ public class PersonalityFactory {
                 0.5,
                 20.0,
                 4.0,
-                150.0,
+                50.0,
                 20.0,
+                0.05,
                 4);
      }
 }


### PR DESCRIPTION
(Also includes minor personality changes)

This PR will change the bid utility from `total_utility/units_added` to `utility_added/units_added`.
This seems to work better, especially in reducing clustering. However, for attacking purposes you want some clustering, as one army could capture a territory, surrounding and thus blocking another of your armies. Because of that there is an extra personality trait that increases clustering: A bonus for goals (which makes it offensive-only) per unit already there.