### PR TITLE
New parameters

### DIFF
--- a/src/infomgmag/CombatEvent.java
+++ b/src/infomgmag/CombatEvent.java
@@ -7,11 +7,12 @@ public class CombatEvent {
     Territory defendingTerritory;
     int attackingUnits;
     int defendingUnits;
+    int attackingCasualties;
+    int defendingCasualties;
     int combatResult;
     boolean captured;
     
     public static final int ATTACKER_WINS = 0, DEFENDER_WINS = 1, ONE_EACH = 2;
-    public static final int NO_CAPTURE = 0, CAPTURE = 1;
     
     CombatEvent(
             Player attackingPlayer, 
@@ -21,7 +22,9 @@ public class CombatEvent {
             int attackingUnits,
             int defendingUnits,
             int combatResult,
-            boolean captured) {
+            boolean captured,
+            int attackingCasualties,
+            int defendingCasualties) {
         this.attackingPlayer = attackingPlayer;
         this.defendingPlayer = defendingPlayer;
         this.attackingTerritory = attackingTerritory;
@@ -30,6 +33,8 @@ public class CombatEvent {
         this.defendingUnits = defendingUnits;
         this.combatResult = combatResult;
         this.captured = captured;
+        this.attackingCasualties = attackingCasualties;
+        this.defendingCasualties = defendingCasualties;
     }
 
     public Player getAttackingPlayer() {
@@ -60,7 +65,17 @@ public class CombatEvent {
         return combatResult;
     }
 
+    public int getAttackingCasualties(){
+        return attackingCasualties;
+    }
+
+    public int getDefendingCasualties(){
+        return defendingCasualties;
+    }
+
     public boolean getCaptured() {
         return captured;
     }
 }
+
+

--- a/src/infomgmag/CombatEvent.java
+++ b/src/infomgmag/CombatEvent.java
@@ -13,7 +13,8 @@ public class CombatEvent {
     boolean captured;
     
     public static final int ATTACKER_WINS = 0, DEFENDER_WINS = 1, ONE_EACH = 2;
-    
+    public static final int NO_CAPTURE = 0, CAPTURE = 1;
+
     CombatEvent(
             Player attackingPlayer, 
             Player defendingPlayer, 

--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -93,8 +93,7 @@ public class Risk implements CombatInterface {
         initializePlayers();
         int currentPlayerIndex = divideTerritories();
         initialPlaceReinforcements(currentPlayerIndex);
-        visuals.setTargetFrameDuration(450);
-
+        visuals.setTargetFrameDuration(45);
         currentPlayer = activePlayers.get(0);
     }
 

--- a/src/infomgmag/Risk.java
+++ b/src/infomgmag/Risk.java
@@ -17,7 +17,7 @@ import java.util.Random;
  * @version FirstPrototype
  * @date 4/5/2018
  */
-public class Risk implements CombatInterface{
+public class Risk implements CombatInterface {
 
     // Variables to be customized by debugger
     private boolean visible = true;
@@ -38,8 +38,8 @@ public class Risk implements CombatInterface{
     private int turn = 0;
     private Integer nrOfStartingUnits;
     private boolean StopGame;
-    
-    private ArrayList<CombatEvent> combatLog;
+
+    public ArrayList<CombatEvent> combatLog;
 
     public static void main(String[] args) {
         random = new Random(System.currentTimeMillis());
@@ -47,49 +47,49 @@ public class Risk implements CombatInterface{
         Risk risk = new Risk();
         risk.run(); //this makes the game run
     }
-    
+
     public static void createDiceOdds() {
-    	DICE_ODDS_ONE = new ArrayList<ArrayList<Double>>();
-    	ArrayList<Double> oneA = new ArrayList<Double>();
-    	oneA.add(15.0/36);
-    	oneA.add(125.0/216);
-    	oneA.add(855.0/1296);
-    	DICE_ODDS_ONE.add(oneA);
-    	ArrayList<Double> oneD = new ArrayList<Double>();
-    	oneD.add(21.0/36);
-    	oneD.add(91.0/216);
-    	oneD.add(441.0/1296);
-    	DICE_ODDS_ONE.add(oneD);
+        DICE_ODDS_ONE = new ArrayList<ArrayList<Double>>();
+        ArrayList<Double> oneA = new ArrayList<Double>();
+        oneA.add(15.0 / 36);
+        oneA.add(125.0 / 216);
+        oneA.add(855.0 / 1296);
+        DICE_ODDS_ONE.add(oneA);
+        ArrayList<Double> oneD = new ArrayList<Double>();
+        oneD.add(21.0 / 36);
+        oneD.add(91.0 / 216);
+        oneD.add(441.0 / 1296);
+        DICE_ODDS_ONE.add(oneD);
         DICE_ODDS_TWO = new ArrayList<ArrayList<Double>>();
         ArrayList<Double> twoA = new ArrayList<Double>();
-        twoA.add(55.0/216);
-        twoA.add(295.0/1296);
-        twoA.add(2890.0/7776);
-    	DICE_ODDS_TWO.add(twoA);
-    	ArrayList<Double> twoD = new ArrayList<Double>();
-        twoD.add(161.0/216);
-        twoD.add(581.0/1296);
-        twoD.add(2275.0/7776);
-    	DICE_ODDS_TWO.add(twoD);
-    	ArrayList<Double> twoL = new ArrayList<Double>();
+        twoA.add(55.0 / 216);
+        twoA.add(295.0 / 1296);
+        twoA.add(2890.0 / 7776);
+        DICE_ODDS_TWO.add(twoA);
+        ArrayList<Double> twoD = new ArrayList<Double>();
+        twoD.add(161.0 / 216);
+        twoD.add(581.0 / 1296);
+        twoD.add(2275.0 / 7776);
+        DICE_ODDS_TWO.add(twoD);
+        ArrayList<Double> twoL = new ArrayList<Double>();
         twoL.add(null);
-        twoL.add(420.0/1296);
-        twoL.add(2611.0/7776);
-    	DICE_ODDS_TWO.add(twoL);
+        twoL.add(420.0 / 1296);
+        twoL.add(2611.0 / 7776);
+        DICE_ODDS_TWO.add(twoL);
     }
-    
+
     public Risk() {
-        visuals = new RiskVisual(this,visible);
+        visuals = new RiskVisual(this, visible);
         board = new Board();
         combatLog = new ArrayList<>();
         defeatedPlayers = new ArrayList<Player>();
         nrOfStartingUnits = 30;
-        initializePlayers(randomPlayers,marsPlayers);
+        initializePlayers(randomPlayers, marsPlayers);
         Integer currentPlayerIndex = divideTerritories();
         initialPlaceReinforcements(currentPlayerIndex);
         currentPlayer = activePlayers.get(0);
     }
-    
+
     public void run() {
         while (!finished()) {
             visuals.update();
@@ -100,7 +100,7 @@ public class Risk implements CombatInterface{
             currentPlayer.placeReinforcements(board);
 
             int startingNrOfTerritories = currentPlayer.getTerritories().size();
-            
+
             currentPlayer.attackPhase((CombatInterface) this);
             currentPlayer.fortifyTerritory(board);
             visuals.update();
@@ -116,7 +116,7 @@ public class Risk implements CombatInterface{
         visuals.log(activePlayers.get(0) + " has won!");
 
         if (visible)
-            while(true) {
+            while (true) {
                 visuals.update();
             }
     }
@@ -169,8 +169,22 @@ public class Risk implements CombatInterface{
         combatMove.getAttackingTerritory().setUnits(combatMove.getAttackingTerritory().getNUnits() - attackLoss);
         combatMove.getDefendingTerritory().setUnits(combatMove.getDefendingTerritory().getNUnits() - defenseLoss);
 
-        // Update number of units on both territories and new owner
         boolean captured = combatMove.getDefendingTerritory().getNUnits() == 0;
+
+        combatLog.add(new CombatEvent(
+                combatMove.getAttackingTerritory().getOwner(),
+                combatMove.getDefendingTerritory().getOwner(),
+                combatMove.getAttackingTerritory(),
+                combatMove.getDefendingTerritory(),
+                combatMove.getAttackingUnits(),
+                combatMove.getDefendingUnits(),
+                attackLoss == 0 ? CombatEvent.ATTACKER_WINS :
+                        (defenseLoss == 0 ? CombatEvent.DEFENDER_WINS :
+                                CombatEvent.ONE_EACH),
+                captured,
+                attackLoss,
+                defenseLoss));
+        // Update number of units on both territories and new owner
         if (captured) {
             Player defender = combatMove.getDefendingTerritory().getOwner();
             combatMove.getDefendingTerritory().setOwner(currentPlayer);
@@ -186,22 +200,10 @@ public class Risk implements CombatInterface{
                     currentPlayer.turnInCards(board);
                 activePlayers.remove(defender);
                 if (activePlayers.size() > 1)
-                	currentPlayer.placeReinforcements(board);
+                    currentPlayer.placeReinforcements(board);
                 defeatedPlayers.add(defender);
             }
         }
-
-        combatLog.add(new CombatEvent(
-                combatMove.getAttackingTerritory().getOwner(), 
-                combatMove.getDefendingTerritory().getOwner(), 
-                combatMove.getAttackingTerritory(), 
-                combatMove.getDefendingTerritory(), 
-                combatMove.getAttackingUnits(), 
-                combatMove.getDefendingUnits(), 
-                attackLoss == 0 ? CombatEvent.ATTACKER_WINS :
-                    (defenseLoss == 0 ? CombatEvent.DEFENDER_WINS :
-                        CombatEvent.ONE_EACH), 
-                captured));
     }
 
     private Integer calculateReinforcements() {
@@ -257,19 +259,19 @@ public class Risk implements CombatInterface{
                 color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
                         Risk.random.nextFloat() * 0.8f + 0.2f);
             }
-            RandomBot player = new RandomBot(objective, 0, "Player " + i + " (Random Bot)",color);
+            RandomBot player = new RandomBot(objective, 0, "Player " + i + " (Random Bot)", color);
             activePlayers.add(player);
         }
 
         for (; i < randoms + marses; i++) {
-	        Color color;
-	        if (i < playerColors.length) {
-	            color = playerColors[i];
-	        } else {
-	            color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
-	                    Risk.random.nextFloat() * 0.8f + 0.2f);
-	        }
-	        Objective objective = new Objective(Objective.type.TOTAL_DOMINATION);
+            Color color;
+            if (i < playerColors.length) {
+                color = playerColors[i];
+            } else {
+                color = new Color(Risk.random.nextFloat() * 0.8f + 0.2f, Risk.random.nextFloat() * 0.8f + 0.2f,
+                        Risk.random.nextFloat() * 0.8f + 0.2f);
+            }
+            Objective objective = new Objective(Objective.type.TOTAL_DOMINATION);
             Personality personality = new Personality(
                     3.5,
                     170.0,
@@ -282,9 +284,10 @@ public class Risk implements CombatInterface{
                     4.0,
                     5.0,
                     4,
-                    0.6);
-	        Mars player = new Mars(this, objective, 0, "Player " + i + " (MARS)",color, personality);
-	        activePlayers.add(player);
+                    0.6,
+                    1000.0);
+            Mars player = new Mars(this, objective, 0, "Player " + i + " (MARS)", color, personality);
+            activePlayers.add(player);
         }
     }
 
@@ -323,7 +326,7 @@ public class Risk implements CombatInterface{
     private boolean finished() {
         return activePlayers.size() == 1 || StopGame;
     }
-    
+
     public static ArrayList<Territory> getConnectedTerritories(Territory origin) {
         ArrayList<Territory> visited = new ArrayList<>();
         ArrayList<Territory> result = new ArrayList<>();
@@ -348,15 +351,21 @@ public class Risk implements CombatInterface{
     }
 
     public static void printError(String str) {
-    	System.err.println("Error:"+str);
-    	System.exit(1);
+        System.err.println("Error:" + str);
+        System.exit(1);
     }
 
-    public ArrayList<Player> getDefeatedPlayers(){
+    public ArrayList<Player> getDefeatedPlayers() {
         return this.defeatedPlayers;
     }
 
     public int getActivePlayerAmount() {
         return activePlayers.size();
     }
+
+    public ArrayList<CombatEvent> getCombatLog() {
+        return combatLog;
+    }
 }
+
+

--- a/src/infomgmag/RiskVisual.java
+++ b/src/infomgmag/RiskVisual.java
@@ -160,7 +160,7 @@ public class RiskVisual extends JFrame {
             g.drawImage(map, 0, 0, gameWidth, gameHeight, null);
     }
 
-    long targetFrameDuration = 100;
+    long targetFrameDuration = 600;
     long frameDuration = 1000;
     long lastFrameTime = targetFrameDuration;
 

--- a/src/infomgmag/Territory.java
+++ b/src/infomgmag/Territory.java
@@ -30,7 +30,6 @@ public class Territory {
         this.adjacentTerritories = new ArrayList<>();
     }
 
-
     public void setOwner(Player newOwner) {
 
         if (this.owner != null)

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -1,7 +1,7 @@
 package infomgmag.mars;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import infomgmag.Continent;
+import infomgmag.Player;
 import infomgmag.Territory;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -15,6 +15,7 @@ public class CountryAgent {
     private ArrayList<Goal> goalList;
     private Mars mars;
     private double value;
+    private boolean ownedByHatedEnemy;
 
     CountryAgent(Territory territory, Mars mars) {
         this.territory = territory;
@@ -36,7 +37,8 @@ public class CountryAgent {
                  enemyArmies() * personality.getEarmiesweight() +
                  territory.getContinentsBorderedAmount() * personality.getContinentBorderWeight() +
                  (enemyOwnsAnEntireContinent() ? 1 : 0) * personality.getEnemyOwnsWholeContinentWeight() +
-                 percentageOfContinentOwned() * personality.getPercentageOfContinentWeight());
+                 percentageOfContinentOwned() * personality.getPercentageOfContinentWeight() +
+                        (ownedByHatedEnemy ? 1 : 0) * personality.getHatedBonus());
     }
 
     public Integer friendlyNeighbours() // calculates how many friendly neighbouring territory border this territory
@@ -282,6 +284,12 @@ public class CountryAgent {
             Goal goal = new Goal();
             goal.addEarlierGoal(this);
             ca.createGoals(goal);
+        }
+    }
+
+    public void setHated(Player player){
+        if (territory.getOwner() == player) {
+            ownedByHatedEnemy = true;
         }
     }
 

--- a/src/infomgmag/mars/CountryAgent.java
+++ b/src/infomgmag/mars/CountryAgent.java
@@ -3,7 +3,6 @@ package infomgmag.mars;
 import infomgmag.Player;
 import infomgmag.Territory;
 
-import java.awt.desktop.SystemEventListener;
 import java.util.ArrayList;
 
 public class CountryAgent {

--- a/src/infomgmag/mars/Mars.java
+++ b/src/infomgmag/mars/Mars.java
@@ -20,6 +20,8 @@ public class Mars extends Player {
     private List<CountryAgent> countryAgents;
     private HashMap<Territory, CountryAgent> countryAgentsByTerritory;
     private Personality personality;
+    private HashMap<Player, Double> playerDispositions;
+    private Risk risk;
 
     public Mars(Risk risk, Objective objective, Integer reinforcements, String name, Color color, Personality personality) {
         super(objective, reinforcements, name, color);
@@ -28,6 +30,8 @@ public class Mars extends Player {
         countryAgents = new ArrayList<>();
         countryAgentsByTerritory = new HashMap<Territory, CountryAgent>();
         this.personality = personality;
+        this.risk = risk;
+        playerDispositions = new HashMap<>();
 
         for (Territory t : risk.getBoard().getTerritories()) {
             CountryAgent ca = new CountryAgent(t, this);
@@ -123,6 +127,7 @@ public class Mars extends Player {
 
     @Override
     public void placeReinforcements(Board board) {
+        this.calculateHatedPlayer();
         for (CountryAgent ca : countryAgents) {
             ca.clearlists();
             ca.calculateOwnershipValue(personality);
@@ -195,6 +200,36 @@ public class Mars extends Player {
             cm.setDefendingTerritory(ob.get().getGoal().getFirstGoal().getTerritory());
             cm.setAttackingUnits(ob.get().reinforcedAgent.getTerritory().getNUnits());
             ci.performCombatMove(cm);
+        }
+    }
+
+    public void calculateHatedPlayer(){
+        Double playerHatred = 0.0;
+        for (Player enemyPlayer : risk.getActivePlayers()){
+            playerDispositions.put(enemyPlayer, playerHatred);
+        }
+        if (risk.combatLog.isEmpty()){ }
+        else {
+            for (int i = 1; i <= Math.min(75, risk.combatLog.size()); i++) {
+                if (risk.combatLog.get(risk.combatLog.size() - i ).getDefendingPlayer() == this) {
+                    System.out.println(risk.combatLog.get(risk.combatLog.size() - i ).getDefendingPlayer().getName() + " defending player");
+                    System.out.println(risk.combatLog.get(risk.combatLog.size() - i ).getAttackingPlayer().getName() + " attacking player");
+                    playerHatred += 0.5;
+                    if (risk.combatLog.get(risk.combatLog.size() - i).getCaptured()) {
+                        playerHatred += 2.0;
+                    }
+                    playerHatred += (risk.combatLog.get(risk.combatLog.size() - i).getDefendingCasualties()) * 0.25;
+                    playerDispositions.put(risk.combatLog.get(risk.combatLog.size() - i).getAttackingPlayer(), playerHatred);
+                }
+            }
+        }
+        for (CountryAgent ca : countryAgents){
+            if (playerHatred != 0) {
+                ca.setHated(playerDispositions.entrySet().stream().max((entry1, entry2) -> entry1.getValue() > entry2.getValue() ? 1 : -1).get().getKey());
+                System.out.println(playerDispositions.entrySet().stream().max((entry1, entry2) -> entry1.getValue() > entry2.getValue() ? 1 : -1).get().getKey() + " most hated player");
+                System.out.println(this.name + "current player");
+                System.out.println(playerDispositions.get(playerDispositions.entrySet().stream().max((entry1, entry2) -> entry1.getValue() > entry2.getValue() ? 1 : -1).get().getKey()) + " value");
+            }
         }
     }
 

--- a/src/infomgmag/mars/Personality.java
+++ b/src/infomgmag/mars/Personality.java
@@ -13,6 +13,7 @@ public class Personality {
     private Double WIN_PERCENTAGE;
     private Double offensiveBonus;
     private Double defensiveBonus;
+    private Double hatedBonus;
 
     public Personality(Double defensiveBonus,
                        Double offensiveBonus,
@@ -25,7 +26,8 @@ public class Personality {
                        Double enemyOwnsWholeContinentWeight,
                        Double percentageOfContinentWeight,
                        Integer goalLength,
-                       Double win_percentage){
+                       Double win_percentage,
+                       Double hatedBonus){
         this.defensiveBonus = defensiveBonus;
         this.offensiveBonus = offensiveBonus;
         this.friendliesweight = friendliesweight;
@@ -38,6 +40,7 @@ public class Personality {
         this.percentageOfContinentWeight = percentageOfContinentWeight;
         this.goalLength = goalLength;
         this.WIN_PERCENTAGE = win_percentage;
+        this.hatedBonus = hatedBonus;
 
     }
 
@@ -89,6 +92,6 @@ public class Personality {
         return offensiveBonus;
     }
 
-
+    public Double getHatedBonus(){ return hatedBonus; }
 
 }

--- a/src/infomgmag/mars/PersonalityFactory.java
+++ b/src/infomgmag/mars/PersonalityFactory.java
@@ -16,7 +16,7 @@ public class PersonalityFactory {
                 5.0,
                 80.0,
                 0.25,
-                4,
+                7,
                 1000,
                 10);
     }


### PR DESCRIPTION
Added function to determine who is the most hated player based on 3 factors
- Amount of attacks against player
- Amount of casualties sustained
- Amount of land captured
Agent then selects a hated target, all territories owned by hated target will receive a bonus. This bonus is configurable (atm 0 for all but the aggressive MARS).
Moved some stuff in the combatlog around so that the timing is right

closes #125